### PR TITLE
Fix torch dataset import compatibility

### DIFF
--- a/dataLoad/DataLoaderRL.py
+++ b/dataLoad/DataLoaderRL.py
@@ -2,7 +2,6 @@ import numpy as np
 import pandas as pd
 import torch
 from torch.utils.data import Dataset
-from torch.utils.data.dataset import T_co
 from operator import itemgetter
 from dataLoad.utils import preProcessor
 
@@ -51,7 +50,7 @@ class RLDataSet(Dataset):
     def __len__(self):
         return self.length-1
 
-    def __getitem__(self, index) -> T_co:
+    def __getitem__(self, index):
         return self.datas[index], self.PriceTMinus1[index], self.PriceT[index], self.PriceTPlusN[index], self.datas[index+1], self.mask[index], self.mask[index+1]  #self.predict_datas[index],self.predict_datas[index+1], self.day_values[index], self.week_values[index]
 
 def stock_fn(batch):


### PR DESCRIPTION
## Summary
- remove outdated T_co import from DataLoader and drop return type annotation to restore compatibility with newer Torch versions

## Testing
- `python main.py` *(fails: [Errno 2] No such file or directory: 'Incremental_Data/N225  || DJI || HSI ||FCHI ||SP500 || N225 || KS11.csv')*


------
https://chatgpt.com/codex/tasks/task_e_68abac1081fc8328950a966101ccd9dd