### PR TITLE
Add yfinance dependency for backtesting script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pandas
 matplotlib
 tabulate
 pillow
+yfinance


### PR DESCRIPTION
## Summary
- Include `yfinance` in requirements to support train_backtest script

## Testing
- `pip install -r requirements.txt`
- `python train_backtest.py --ticker AAPL --train_start 2020-01-01 --train_end 2020-03-01 --test_start 2020-03-02 --test_end 2020-06-01 --epochs 1`


------
https://chatgpt.com/codex/tasks/task_e_68abba0a9c3883288170a7dbf4fa6322