### PR TITLE
Add script for training and backtesting with local stock data

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,17 @@ To execute the code, simply run the following command:
 ```bash
 python main.py
 ```
+
+## Train and backtest on local data
+
+Use `train_backtest_local.py` to train a DDQN agent on a CSV file located in `Incremental_Data` and evaluate its performance.
+
+Example:
+```bash
+python train_backtest_local.py --data_name N225 \
+    --train_start 2020-01-01 --train_end 2020-12-31 \
+    --test_start 2021-01-01 --test_end 2021-12-31 \
+    --epochs 1
+```
+
+The script prints the annualized return, total return, and maximum drawdown after the backtest.

--- a/dataLoad/DataLoaderRL.py
+++ b/dataLoad/DataLoaderRL.py
@@ -26,8 +26,12 @@ class RLDataSet(Dataset):
         self.day_values = []
         self.week_values = []
         self.start_point = cfg.input.start_point
-        _,_, data, self.data_stamp = preProcessor(pd.read_csv(csvFilePath), startDate, endDate)
-        _data, _priceTMinus1, _priceToday, _PriceTPlusN, _mask = self.splitData(data,self.data_stamp, cfg.input.length, cfg.output.length)
+        _, _, data, self.data_stamp = preProcessor(pd.read_csv(csvFilePath), startDate, endDate)
+        if data.shape[1] == 10:
+            data = data[:, :5]
+        _data, _priceTMinus1, _priceToday, _PriceTPlusN, _mask = self.splitData(
+            data, self.data_stamp, cfg.input.length, cfg.output.length
+        )
         self.datas += _data
         self.PriceTMinus1 += _priceTMinus1
         self.PriceT += _priceToday

--- a/train_backtest_local.py
+++ b/train_backtest_local.py
@@ -1,0 +1,103 @@
+import argparse
+import os
+from datetime import datetime
+
+import torch
+from omegaconf import OmegaConf
+from torch.utils.data import DataLoader
+
+from dataLoad.DataLoaderRL import RLDataSet, stock_fn
+from dataLoad.utils import normalization
+from agents.DQNagent import DDQN
+from Env.TradingEnv import TradingEnv
+from utils.estimator import PerformanceEstimator
+from utils.utils import setup_seed
+
+
+def train_and_backtest(args) -> None:
+    """Train an agent on a local CSV file and run a backtest."""
+    setup_seed(1)
+    cfg = OmegaConf.load("configs/common.yaml")
+    cfg.dataSetName = args.data_name
+    cfg.ValDataName = args.data_name
+    cfg.time.train_startingDate = args.train_start
+    cfg.time.train_endingDate = args.train_end
+    cfg.time.test_startingDate = args.test_start
+    cfg.time.test_endingDate = args.test_end
+    cfg.agent.ModelPath = os.path.join("result", f"{args.data_name}_{cfg.agent.algorithm}.pth")
+    cfg.device = "cpu"
+
+    data_path = os.path.join(cfg.dataDir, f"{args.data_name}.csv")
+    if not os.path.exists(data_path):
+        raise FileNotFoundError(f"{data_path} not found")
+
+    train_dataset = RLDataSet(
+        csvFilePath=data_path,
+        startDate=datetime.strptime(args.train_start, "%Y-%m-%d"),
+        endDate=datetime.strptime(args.train_end, "%Y-%m-%d"),
+        cfg=cfg,
+    )
+    train_loader = DataLoader(train_dataset, batch_size=1, collate_fn=stock_fn)
+
+    test_dataset = RLDataSet(
+        csvFilePath=data_path,
+        startDate=datetime.strptime(args.test_start, "%Y-%m-%d"),
+        endDate=datetime.strptime(args.test_end, "%Y-%m-%d"),
+        cfg=cfg,
+    )
+    test_loader = DataLoader(test_dataset, batch_size=1, collate_fn=stock_fn)
+
+    env = TradingEnv(cfg, init_money=cfg.train.init_money)
+    agent = DDQN(cfg)
+
+    for epoch in range(args.epochs):
+        env.reset(len(train_loader))
+        for iteration, batch in enumerate(train_loader):
+            datas, price_tm1, price_t, price_tpn, datas_next, mask, mask_next = [i.to(cfg.device) for i in batch]
+            if cfg.normalization:
+                datas = normalization(datas)
+                datas_next = normalization(datas_next)
+            if iteration == 0:
+                env.setInitPrice(price_t)
+            env.setState(iteration, price_tm1, price_t, price_tpn)
+            env.getNday()
+            action = agent.act(datas, train=True)
+            reward = env.agentStep(datas, action)
+            agent.memory.Agent_add(datas, action, reward, datas_next)
+            if len(agent.memory) > cfg.train.batch_size and iteration % cfg.train.train_interval == 0:
+                batch_sample = agent.memory.Agent_sample(cfg.train.batch_size)
+                agent.learn(batch_sample)
+        torch.save(agent.policy_net.state_dict(), cfg.agent.ModelPath)
+
+    agent.policy_net.eval()
+    env.reset(len(test_loader))
+    for iteration, batch in enumerate(test_loader):
+        datas, price_tm1, price_t, price_tpn, datas_next, mask, mask_next = [i.to(cfg.device) for i in batch]
+        if cfg.normalization:
+            datas = normalization(datas)
+        if iteration == 0:
+            env.setInitPrice(price_t)
+        env.setState(iteration, price_tm1, price_t, price_tpn)
+        env.getNday()
+        action = agent.act(datas, train=False)
+        env.agentStep(datas, action)
+
+    analyser = PerformanceEstimator(cfg, env.account, "result")
+    annual_ret = analyser.computeAnnualizedReturn(len(test_loader))
+    total_ret = analyser.computeCR() * 100
+    max_dd, _ = analyser.computeMaxDrawdown()
+    print(f"Annualized Return: {annual_ret:.2f}%")
+    print(f"Total Return: {total_ret:.2f}%")
+    print(f"Max Drawdown: {max_dd:.2f}%")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Train and backtest an RL trading agent using local CSV data")
+    parser.add_argument("--data_name", required=True, help="CSV file name located in Incremental_Data without extension")
+    parser.add_argument("--train_start", required=True, help="Training start date (YYYY-MM-DD)")
+    parser.add_argument("--train_end", required=True, help="Training end date (YYYY-MM-DD)")
+    parser.add_argument("--test_start", required=True, help="Testing start date (YYYY-MM-DD)")
+    parser.add_argument("--test_end", required=True, help="Testing end date (YYYY-MM-DD)")
+    parser.add_argument("--epochs", type=int, default=1, help="Number of training epochs")
+    args = parser.parse_args()
+    train_and_backtest(args)


### PR DESCRIPTION
## Summary
- add `train_backtest_local.py` to train and evaluate a DDQN agent on CSV data in `Incremental_Data`
- document how to run the new script in the README
- restore original preprocessing in `dataLoad/utils.py` and trim duplicate weekly features in `RLDataSet`

## Testing
- `python -m py_compile train_backtest_local.py dataLoad/utils.py dataLoad/DataLoaderRL.py`
- `python train_backtest_local.py --data_name DJI --train_start 2023-01-01 --train_end 2023-03-31 --test_start 2023-04-01 --test_end 2023-06-30 --epochs 1`
- `python train_backtest_local.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68ac67880e448328a1e78da0557e7207